### PR TITLE
Handling the upload of large files

### DIFF
--- a/example/dapp-store/config.yaml
+++ b/example/dapp-store/config.yaml
@@ -19,25 +19,20 @@ app:
     - purpose: icon
       uri: ./media/app_icon.jpeg
 release:
-  address: HeXP8pLxxzWPo1j7FwsytrCBN9Q7HZ3MA8TVCVGj5eCA
+  address: 9FvtmaMMQEatbr1Quj9i19t8fbNcZj9XEATH7q2Puf78
   media:
     - purpose: screenshot
       uri: ./media/app_screenshot.png
   files:
     - purpose: install
-      uri: ./files/app-debug.apk
+      uri: ./files/app-prod-release.apk
   catalog:
     en-US:
-      name: >-
-        A nice, helpful dApp name
-      short_description: >-
-        Some wonderful release notes
-      long_description: >-
-        Some wonderful release notes, in long-form
-      new_in_version: >-
-        Something new in this version
-      saga_features: >-
-        Some information about saga specific features
+      name: A nice, helpful dApp name
+      short_description: Some wonderful release notes
+      long_description: Some wonderful release notes, in long-form
+      new_in_version: Something new in this version
+      saga_features: Some information about saga specific features
 solana_mobile_dapp_publisher_portal:
   google_store_package: com.company.dapp.otherpkg
   testing_instructions: >-

--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
     "prettier": "^2.7.1",
     "shx": "^0.3.4",
     "typescript": "^4.7.4"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@metaplex-foundation/js@0.17.9": "patches/@metaplex-foundation__js@0.17.9.patch"
+    }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "prebuild": "pnpm run clean"
   },
   "devDependencies": {
-    "@metaplex-foundation/js": "^0.17.1",
+    "@metaplex-foundation/js": "0.17.9",
     "@types/commander": "^2.12.2",
     "@types/debug": "^4.1.7",
     "@types/js-yaml": "^4.0.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-mobile/dapp-store-cli",
-  "version": "0.1.1-1",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
@@ -35,7 +35,7 @@
     "shx": "^0.3.4"
   },
   "dependencies": {
-    "@solana-mobile/dapp-store-publishing-tools": "workspace:0.1.1-1",
+    "@solana-mobile/dapp-store-publishing-tools": "workspace:0.1.1",
     "@solana/web3.js": "1.68.0",
     "ajv": "^8.11.0",
     "commander": "^9.4.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "shx": "^0.3.4"
   },
   "dependencies": {
-    "@metaplex-foundation/js": "^0.17.1",
+    "@metaplex-foundation/js": "0.17.9",
     "@solana/web3.js": "1.68.0",
     "ajv": "^8.11.0",
     "axios": "1.1.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-mobile/dapp-store-publishing-tools",
-  "version": "0.1.1-1",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/patches/@metaplex-foundation__js@0.17.9.patch
+++ b/patches/@metaplex-foundation__js@0.17.9.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/esm/plugins/nftModule/operations/uploadMetadata.mjs b/dist/esm/plugins/nftModule/operations/uploadMetadata.mjs
+index 89c47c83d1f4b27f36461265f717dfcac4e54cc5..5311206572250f56c18e1f6c49bd404a98e1f19a 100644
+--- a/dist/esm/plugins/nftModule/operations/uploadMetadata.mjs
++++ b/dist/esm/plugins/nftModule/operations/uploadMetadata.mjs
+@@ -68,8 +68,9 @@ const replaceAssetsWithUris = (input, replacements) => {
+   walk(clone, (next, value, key, parent) => {
+     if (isMetaplexFile(value) && index < replacements.length) {
+       parent[key] = replacements[index++];
++    } else {
++      next(value);
+     }
+-    next(value);
+   });
+   return clone;
+ };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: 5.4
 
+patchedDependencies:
+  '@metaplex-foundation/js@0.17.9':
+    hash: qpzzrpczuufntb5glctma5x7sy
+    path: patches/@metaplex-foundation__js@0.17.9.patch
+
 importers:
 
   .:
@@ -34,7 +39,7 @@ importers:
 
   packages/cli:
     specifiers:
-      '@metaplex-foundation/js': ^0.17.1
+      '@metaplex-foundation/js': 0.17.9
       '@solana-mobile/dapp-store-publishing-tools': workspace:0.1.1
       '@solana/web3.js': 1.68.0
       '@types/commander': ^2.12.2
@@ -61,7 +66,7 @@ importers:
       js-yaml: 4.1.0
       tweetnacl: 1.0.3
     devDependencies:
-      '@metaplex-foundation/js': 0.17.2
+      '@metaplex-foundation/js': 0.17.9_2qoyzwmpaczaj2mabgmoz6ccpy
       '@types/commander': 2.12.2
       '@types/debug': 4.1.7
       '@types/js-yaml': 4.0.5
@@ -69,7 +74,7 @@ importers:
 
   packages/core:
     specifiers:
-      '@metaplex-foundation/js': ^0.17.1
+      '@metaplex-foundation/js': 0.17.9
       '@solana/web3.js': 1.68.0
       '@types/debug': ^4.1.7
       '@types/mime': ^3.0.1
@@ -82,7 +87,7 @@ importers:
       mime: ^3.0.0
       shx: ^0.3.4
     dependencies:
-      '@metaplex-foundation/js': 0.17.2
+      '@metaplex-foundation/js': 0.17.9_2qoyzwmpaczaj2mabgmoz6ccpy
       '@solana/web3.js': 1.68.0
       ajv: 8.11.0
       axios: 1.1.3_debug@4.3.4
@@ -490,6 +495,19 @@ packages:
       - supports-color
       - utf-8-validate
 
+  /@metaplex-foundation/beet-solana/0.4.0:
+    resolution: {integrity: sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==}
+    dependencies:
+      '@metaplex-foundation/beet': 0.7.1
+      '@solana/web3.js': 1.69.0
+      bs58: 5.0.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   /@metaplex-foundation/beet/0.4.0:
     resolution: {integrity: sha512-2OAKJnLatCc3mBXNL0QmWVQKAWK2C7XDfepgL0p/9+8oSx4bmRAFHFqptl1A/C0U5O3dxGwKfmKluW161OVGcA==}
     dependencies:
@@ -520,20 +538,19 @@ packages:
   /@metaplex-foundation/cusper/0.0.2:
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
 
-  /@metaplex-foundation/js/0.17.2:
-    resolution: {integrity: sha512-K6+3Y15EshmbAEMnok/yCmy9Bus4FJ+j8ZipeUrcbLKh745Omy0IGUzrWFPu2UGYWxOY/oY28oMjMhEx+wb5OQ==}
-    engines: {node: '>=16.0'}
+  /@metaplex-foundation/js/0.17.9_2qoyzwmpaczaj2mabgmoz6ccpy:
+    resolution: {integrity: sha512-msMGWSYetSVWmIXpDKI5Y3WZtTrCjF6QRQ8BpsXKoNs6xAKPvSuT9OGay/mbOs+/pMNHVPt8lFfl281yBN/MxA==}
     dependencies:
       '@bundlr-network/client': 0.8.9_debug@4.3.4
       '@metaplex-foundation/beet': 0.7.1
       '@metaplex-foundation/mpl-auction-house': 2.3.0
-      '@metaplex-foundation/mpl-candy-guard': 0.0.2
-      '@metaplex-foundation/mpl-candy-machine': 4.7.1
+      '@metaplex-foundation/mpl-candy-guard': 0.3.0
+      '@metaplex-foundation/mpl-candy-machine': 5.0.0
       '@metaplex-foundation/mpl-candy-machine-core': 0.1.2
       '@metaplex-foundation/mpl-token-metadata': 2.3.3
       '@noble/ed25519': 1.7.1
-      '@noble/hashes': 1.1.3
-      '@solana/spl-token': 0.3.5_@solana+web3.js@1.69.0
+      '@noble/hashes': 1.1.4
+      '@solana/spl-token': 0.3.6_@solana+web3.js@1.69.0
       '@solana/web3.js': 1.69.0
       bignumber.js: 9.1.0
       bn.js: 5.2.1
@@ -551,6 +568,7 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
+    patched: true
 
   /@metaplex-foundation/mpl-auction-house/2.3.0:
     resolution: {integrity: sha512-J27In0C/B0ETsDvy/3HkopiZ+I7AR4TlEzU0T2URKsreP4ghWGUUmhldkblxY7KhgLpvvQN/L0IaIBt+TFWU8g==}
@@ -566,8 +584,8 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@metaplex-foundation/mpl-candy-guard/0.0.2:
-    resolution: {integrity: sha512-BYDhfR2KTAYqbSK5LK2IUyjo4J8glkRkQy+Gs7kXid9PpvPzkjjPNqz44FtRyz/KDxmMgqWeDHY6FSWDmA5pjQ==}
+  /@metaplex-foundation/mpl-candy-guard/0.3.0:
+    resolution: {integrity: sha512-YJOZPtAirPqBMd48GOUQ+lav71C70QrA9OQnXsuAbbdl7jKlvbL72C9CnSNBTfdW2I+zPOmDL5H3CQddvgIWlA==}
     dependencies:
       '@metaplex-foundation/beet': 0.4.0
       '@metaplex-foundation/beet-solana': 0.3.1
@@ -594,29 +612,18 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@metaplex-foundation/mpl-candy-machine/4.7.1:
-    resolution: {integrity: sha512-tBNRAfBE/rYy9pe2aJD4gTFw+pgQ11o3AJjoYGB4+05ow0VjJMSt6kQGzHm2LRPgdLY4diKAq8qHvgsbV5ikNQ==}
+  /@metaplex-foundation/mpl-candy-machine/5.0.0:
+    resolution: {integrity: sha512-df2OmZ4s8PJXQXtGAyfZIIitwJPKebtj4f8tab/o5VNhYsW5M9YKfMyAEBBNHm1n/xz+C8Lxy05e6qo3nU/30g==}
     dependencies:
-      '@metaplex-foundation/beet': 0.4.0
-      '@metaplex-foundation/beet-solana': 0.3.1
+      '@metaplex-foundation/beet': 0.7.1
+      '@metaplex-foundation/beet-solana': 0.4.0
       '@metaplex-foundation/cusper': 0.0.2
-      '@metaplex-foundation/mpl-core': 0.6.1
+      '@solana/spl-token': 0.3.6_@solana+web3.js@1.69.0
       '@solana/web3.js': 1.69.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - supports-color
-      - utf-8-validate
-
-  /@metaplex-foundation/mpl-core/0.6.1:
-    resolution: {integrity: sha512-6R4HkfAqU2EUakNbVLcCmka0YuQTLGTbHJ62ig765+NRWuB2HNGUQ1HfHcRsGnyxhlCvwKK79JE01XUjFE+dzw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    dependencies:
-      '@solana/web3.js': 1.69.0
-      bs58: 4.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
       - utf-8-validate
 
   /@metaplex-foundation/mpl-token-metadata/2.3.3:
@@ -638,12 +645,8 @@ packages:
   /@noble/ed25519/1.7.1:
     resolution: {integrity: sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==}
 
-  /@noble/hashes/1.1.3:
-    resolution: {integrity: sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==}
-
   /@noble/hashes/1.1.4:
     resolution: {integrity: sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA==}
-    dev: false
 
   /@noble/secp256k1/1.7.0:
     resolution: {integrity: sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==}
@@ -721,8 +724,8 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@solana/spl-token/0.3.5_@solana+web3.js@1.69.0:
-    resolution: {integrity: sha512-0bGC6n415lGjKu02gkLOIpP1wzndSP0SHwN9PefJ+wKAhmfU1rl3AV1Pa41uap2kzSCD6F9642ngNO8KXPvh/g==}
+  /@solana/spl-token/0.3.6_@solana+web3.js@1.69.0:
+    resolution: {integrity: sha512-P9pTXjDIRvVbjr3J0mCnSamYqLnICeds7IoH1/Ro2R9OBuOHdp5pqKZoscfZ3UYrgnCWUc1bc9M2m/YPHjw+1g==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.47.4
@@ -776,7 +779,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.6
       '@noble/ed25519': 1.7.1
-      '@noble/hashes': 1.1.3
+      '@noble/hashes': 1.1.4
       '@noble/secp256k1': 1.7.0
       '@solana/buffer-layout': 4.0.0
       bigint-buffer: 1.1.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
   packages/cli:
     specifiers:
       '@metaplex-foundation/js': ^0.17.1
-      '@solana-mobile/dapp-store-publishing-tools': workspace:0.1.1-1
+      '@solana-mobile/dapp-store-publishing-tools': workspace:0.1.1
       '@solana/web3.js': 1.68.0
       '@types/commander': ^2.12.2
       '@types/debug': ^4.1.7


### PR DESCRIPTION
please forgive me for what i'm about to do

this uses the [pnpm patch](https://pnpm.io/cli/patch) and [pnpm patch-commit](https://pnpm.io/cli/patch-commit) commands to allow for a manually updated version of `@metaplex-foundation/js` whose patch lives below.

true to @sdlaver's debugging session, the recurse over the keys in the metadata should not recurse to the child if it is a MetaplexFile.

[proof of upload](https://solscan.io/token/9FvtmaMMQEatbr1Quj9i19t8fbNcZj9XEATH7q2Puf78?cluster=devnet#metadata), using the 210mb Audius APK

unfortunately, this reveals another issue—the way that Bundlr works, it submits a transaction of SOL to exchange for AR to pay for the upload, but since Solana transactions expire if the transaction / upload cannot succeed within a minute, the blockhash expires and we have to start again. need to think about this more deeply; i suspect we may have to do a manual upload of APKs in the interim.